### PR TITLE
Changes from background agent bc-4940fee1-54df-4d8a-938f-ec3613dea4d2

### DIFF
--- a/ai_design_inspiration_hub/README.md
+++ b/ai_design_inspiration_hub/README.md
@@ -1,0 +1,43 @@
+AI Design Inspiration Hub (Scaffold)
+
+This repository contains a scaffold for the AI Design Inspiration Hub Flutter app targeting macOS aesthetics with `macos_ui`.
+
+Contents:
+- Data models and SQLite schema via `sqflite`
+- Repositories and DAOs
+- Storage service for images under the app support directory
+- Stubs for upload, image analysis (color palette), MCP server, menubar, and JSON export
+
+Structure:
+- lib/app.dart, lib/main.dart: App shell (macOS styled)
+- lib/services/database.dart: SQLite init and schema
+- lib/services/storage_service.dart: File storage helpers
+- lib/models/*: Domain models
+- lib/data/dao/*: DAOs
+- lib/data/repositories/*: Repositories
+- lib/features/*: Feature stubs (upload, analysis, export, MCP, menubar)
+
+Getting Started:
+- Install Flutter SDK (3.22+) and Dart SDK.
+- Run:
+- flutter pub get
+- flutter run -d macos
+
+Note: Flutter may not be installed in this environment. Once Flutter is available locally, the app should run.
+
+Roadmap (MVP):
+- Implement real MCP server per spec (listScreenshots, getScreenshotMetadata, getDesignSpecifications)
+- Wire tags/categories and search filters
+- Add drag-and-drop and file picker upload UI
+- Expand analysis beyond color palette (OCR, layout heuristics)
+- Menubar actions: show window, upload, start/stop MCP
+- JSON export options in UI
+
+Data:
+- Database: Application Support/AI Design Inspiration Hub/inspiration_hub.db
+- Images: Application Support/AI Design Inspiration Hub/Images/
+
+Security:
+- MCP stub includes API key placeholder. Replace with secure storage and validation.
+
+License: TBD

--- a/ai_design_inspiration_hub/lib/app.dart
+++ b/ai_design_inspiration_hub/lib/app.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/widgets.dart';
+import 'package:macos_ui/macos_ui.dart';
+
+class InspirationHubApp extends StatelessWidget {
+  const InspirationHubApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MacosApp(
+      debugShowCheckedModeBanner: false,
+      title: 'AI Design Inspiration Hub',
+      theme: MacosThemeData(
+        brightness: Brightness.light,
+      ),
+      home: const _HomeShell(),
+    );
+  }
+}
+
+class _HomeShell extends StatefulWidget {
+  const _HomeShell({super.key});
+
+  @override
+  State<_HomeShell> createState() => _HomeShellState();
+}
+
+class _HomeShellState extends State<_HomeShell> {
+  @override
+  Widget build(BuildContext context) {
+    return MacosWindow(
+      titleBar: const TitleBar(
+        title: Text('AI Design Inspiration Hub'),
+      ),
+      child: MacosScaffold(
+        children: [
+          ContentArea(
+            builder: (context, scrollController) {
+              return Center(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: const [
+                    Text('Welcome to AI Design Inspiration Hub'),
+                    SizedBox(height: 8),
+                    Text('Scaffold placeholder — add screenshots to get started'),
+                  ],
+                ),
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/ai_design_inspiration_hub/lib/data/dao/category_dao.dart
+++ b/ai_design_inspiration_hub/lib/data/dao/category_dao.dart
@@ -1,0 +1,24 @@
+import 'package:sqflite/sqflite.dart';
+
+import '../../models/category.dart';
+import '../../services/database.dart';
+
+class CategoryDao {
+  Future<void> insert(CategoryModel category, {Database? tx}) async {
+    final db = tx ?? await AppDatabase.database;
+    await db.insert('Categories', category.toMap(), conflictAlgorithm: ConflictAlgorithm.ignore);
+  }
+
+  Future<CategoryModel?> getById(String id) async {
+    final db = await AppDatabase.database;
+    final rows = await db.query('Categories', where: 'id = ?', whereArgs: [id], limit: 1);
+    if (rows.isEmpty) return null;
+    return CategoryModel.fromMap(rows.first);
+  }
+
+  Future<List<CategoryModel>> listAll() async {
+    final db = await AppDatabase.database;
+    final rows = await db.query('Categories', orderBy: 'name COLLATE NOCASE ASC');
+    return rows.map((e) => CategoryModel.fromMap(e)).toList();
+  }
+}

--- a/ai_design_inspiration_hub/lib/data/dao/design_spec_dao.dart
+++ b/ai_design_inspiration_hub/lib/data/dao/design_spec_dao.dart
@@ -1,0 +1,18 @@
+import 'package:sqflite/sqflite.dart';
+
+import '../../models/design_specification.dart';
+import '../../services/database.dart';
+
+class DesignSpecDao {
+  Future<void> upsert(DesignSpecificationModel spec, {Database? tx}) async {
+    final db = tx ?? await AppDatabase.database;
+    await db.insert('Design_Specifications', spec.toMap(), conflictAlgorithm: ConflictAlgorithm.replace);
+  }
+
+  Future<DesignSpecificationModel?> getByScreenshotId(String screenshotId) async {
+    final db = await AppDatabase.database;
+    final rows = await db.query('Design_Specifications', where: 'screenshot_id = ?', whereArgs: [screenshotId], limit: 1);
+    if (rows.isEmpty) return null;
+    return DesignSpecificationModel.fromMap(rows.first);
+  }
+}

--- a/ai_design_inspiration_hub/lib/data/dao/screenshot_dao.dart
+++ b/ai_design_inspiration_hub/lib/data/dao/screenshot_dao.dart
@@ -1,0 +1,39 @@
+import 'package:sqflite/sqflite.dart';
+
+import '../../models/screenshot.dart';
+import '../../services/database.dart';
+
+class ScreenshotDao {
+  Future<void> insert(ScreenshotModel screenshot, {Database? tx}) async {
+    final db = tx ?? await AppDatabase.database;
+    await db.insert('Screenshots', screenshot.toMap(), conflictAlgorithm: ConflictAlgorithm.replace);
+  }
+
+  Future<ScreenshotModel?> getById(String id, {Database? tx}) async {
+    final db = tx ?? await AppDatabase.database;
+    final rows = await db.query('Screenshots', where: 'id = ?', whereArgs: [id], limit: 1);
+    if (rows.isEmpty) return null;
+    return ScreenshotModel.fromMap(rows.first);
+  }
+
+  Future<List<ScreenshotModel>> listAll({int? limit, int? offset}) async {
+    final db = await AppDatabase.database;
+    final rows = await db.query(
+      'Screenshots',
+      orderBy: 'datetime(creation_date) DESC NULLS LAST, datetime(upload_timestamp) DESC',
+      limit: limit,
+      offset: offset,
+    );
+    return rows.map((e) => ScreenshotModel.fromMap(e)).toList();
+  }
+
+  Future<void> update(ScreenshotModel screenshot, {Database? tx}) async {
+    final db = tx ?? await AppDatabase.database;
+    await db.update('Screenshots', screenshot.toMap(), where: 'id = ?', whereArgs: [screenshot.id]);
+  }
+
+  Future<void> delete(String id, {Database? tx}) async {
+    final db = tx ?? await AppDatabase.database;
+    await db.delete('Screenshots', where: 'id = ?', whereArgs: [id]);
+  }
+}

--- a/ai_design_inspiration_hub/lib/data/dao/tag_dao.dart
+++ b/ai_design_inspiration_hub/lib/data/dao/tag_dao.dart
@@ -1,0 +1,31 @@
+import 'package:sqflite/sqflite.dart';
+
+import '../../models/tag.dart';
+import '../../services/database.dart';
+
+class TagDao {
+  Future<void> insert(TagModel tag, {Database? tx}) async {
+    final db = tx ?? await AppDatabase.database;
+    await db.insert('Tags', tag.toMap(), conflictAlgorithm: ConflictAlgorithm.ignore);
+  }
+
+  Future<TagModel?> getById(String id) async {
+    final db = await AppDatabase.database;
+    final rows = await db.query('Tags', where: 'id = ?', whereArgs: [id], limit: 1);
+    if (rows.isEmpty) return null;
+    return TagModel.fromMap(rows.first);
+  }
+
+  Future<TagModel?> getByName(String name) async {
+    final db = await AppDatabase.database;
+    final rows = await db.query('Tags', where: 'name = ?', whereArgs: [name], limit: 1);
+    if (rows.isEmpty) return null;
+    return TagModel.fromMap(rows.first);
+  }
+
+  Future<List<TagModel>> listAll() async {
+    final db = await AppDatabase.database;
+    final rows = await db.query('Tags', orderBy: 'name COLLATE NOCASE ASC');
+    return rows.map((e) => TagModel.fromMap(e)).toList();
+  }
+}

--- a/ai_design_inspiration_hub/lib/data/repositories/category_repository.dart
+++ b/ai_design_inspiration_hub/lib/data/repositories/category_repository.dart
@@ -1,0 +1,9 @@
+import '../dao/category_dao.dart';
+import '../../models/category.dart';
+
+class CategoryRepository {
+  final CategoryDao _dao = CategoryDao();
+
+  Future<void> createIfMissing(CategoryModel category) => _dao.insert(category);
+  Future<List<CategoryModel>> listAll() => _dao.listAll();
+}

--- a/ai_design_inspiration_hub/lib/data/repositories/design_spec_repository.dart
+++ b/ai_design_inspiration_hub/lib/data/repositories/design_spec_repository.dart
@@ -1,0 +1,9 @@
+import '../dao/design_spec_dao.dart';
+import '../../models/design_specification.dart';
+
+class DesignSpecRepository {
+  final DesignSpecDao _dao = DesignSpecDao();
+
+  Future<void> upsert(DesignSpecificationModel spec) => _dao.upsert(spec);
+  Future<DesignSpecificationModel?> getByScreenshotId(String screenshotId) => _dao.getByScreenshotId(screenshotId);
+}

--- a/ai_design_inspiration_hub/lib/data/repositories/screenshot_repository.dart
+++ b/ai_design_inspiration_hub/lib/data/repositories/screenshot_repository.dart
@@ -1,0 +1,24 @@
+import 'package:sqflite/sqflite.dart';
+
+import '../../models/screenshot.dart';
+import '../../services/database.dart';
+import '../dao/screenshot_dao.dart';
+
+class ScreenshotRepository {
+  final ScreenshotDao _dao = ScreenshotDao();
+
+  Future<void> create(ScreenshotModel screenshot) => _dao.insert(screenshot);
+
+  Future<ScreenshotModel?> getById(String id) => _dao.getById(id);
+
+  Future<List<ScreenshotModel>> listAll({int? limit, int? offset}) => _dao.listAll(limit: limit, offset: offset);
+
+  Future<void> update(ScreenshotModel screenshot) => _dao.update(screenshot);
+
+  Future<void> delete(String id) => _dao.delete(id);
+
+  Future<void> withTransaction(Future<void> Function(Database tx) action) async {
+    final db = await AppDatabase.database;
+    await db.transaction(action);
+  }
+}

--- a/ai_design_inspiration_hub/lib/data/repositories/tag_repository.dart
+++ b/ai_design_inspiration_hub/lib/data/repositories/tag_repository.dart
@@ -1,0 +1,10 @@
+import '../dao/tag_dao.dart';
+import '../../models/tag.dart';
+
+class TagRepository {
+  final TagDao _dao = TagDao();
+
+  Future<void> createIfMissing(TagModel tag) => _dao.insert(tag);
+  Future<TagModel?> getByName(String name) => _dao.getByName(name);
+  Future<List<TagModel>> listAll() => _dao.listAll();
+}

--- a/ai_design_inspiration_hub/lib/features/analysis/analysis_stub.dart
+++ b/ai_design_inspiration_hub/lib/features/analysis/analysis_stub.dart
@@ -1,0 +1,55 @@
+import 'dart:typed_data';
+
+import 'package:image/image.dart' as img;
+import 'package:uuid/uuid.dart';
+
+import '../../models/design_specification.dart';
+import '../../data/repositories/design_spec_repository.dart';
+
+class AnalysisEngineStub {
+  final DesignSpecRepository _specRepo = DesignSpecRepository();
+  final _uuid = const Uuid();
+
+  Future<DesignSpecificationModel> analyzeAndSave(String screenshotId, Uint8List bytes) async {
+    final palette = _extractDominantColors(bytes, count: 5);
+    final spec = DesignSpecificationModel(
+      id: _uuid.v4(),
+      screenshotId: screenshotId,
+      colorPalette: palette
+          .map((c) => {
+                'hex': _toHex(c),
+                'role': 'palette',
+              })
+          .toList(),
+      layoutStructure: {
+        'description': 'Basic layout inference not yet implemented',
+      },
+      analysisTimestampIso: DateTime.now().toUtc().toIso8601String(),
+      analysisEngineVersion: 'stub-0.1',
+    );
+    await _specRepo.upsert(spec);
+    return spec;
+  }
+
+  List<img.ColorRgb8> _extractDominantColors(Uint8List bytes, {int count = 5}) {
+    final image = img.decodeImage(bytes);
+    if (image == null) return [];
+    final reduced = img.quantize(image, numberOfColors: count);
+    final unique = <int, int>{};
+    for (final pixel in reduced) {
+      final key = (pixel.r << 16) | (pixel.g << 8) | pixel.b;
+      unique.update(key, (v) => v + 1, ifAbsent: () => 1);
+    }
+    final sorted = unique.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+    final top = sorted.take(count).map((e) => e.key).toList();
+    return top
+        .map((rgb) => img.ColorRgb8(((rgb >> 16) & 0xFF), ((rgb >> 8) & 0xFF), (rgb & 0xFF)))
+        .toList();
+  }
+
+  String _toHex(img.ColorRgb8 c) {
+    String two(int v) => v.toRadixString(16).padLeft(2, '0');
+    return '#${two(c.r)}${two(c.g)}${two(c.b)}'.toUpperCase();
+  }
+}

--- a/ai_design_inspiration_hub/lib/features/export/export_service.dart
+++ b/ai_design_inspiration_hub/lib/features/export/export_service.dart
@@ -1,0 +1,48 @@
+import 'dart:convert';
+import 'dart:io';
+
+import '../../data/repositories/design_spec_repository.dart';
+import '../../data/repositories/screenshot_repository.dart';
+
+class ExportService {
+  final ScreenshotRepository _screensRepo = ScreenshotRepository();
+  final DesignSpecRepository _specRepo = DesignSpecRepository();
+
+  Future<File> exportToJson({required List<String> screenshotIds, required File targetFile}) async {
+    final List<Map<String, Object?>> out = [];
+    for (final id in screenshotIds) {
+      final screenshot = await _screensRepo.getById(id);
+      if (screenshot == null) continue;
+      final spec = await _specRepo.getByScreenshotId(id);
+      out.add({
+        'id': screenshot.id,
+        'title': screenshot.title,
+        'description': screenshot.description,
+        'image_filename': screenshot.imagePath,
+        'creation_date': screenshot.creationDateIso,
+        'source_url': screenshot.sourceUrl,
+        'upload_timestamp': screenshot.uploadTimestampIso,
+        // Tags/Categories omitted in stub; add when link tables wired via repos
+        'design_specifications': spec == null
+            ? null
+            : {
+                'layout_structure': spec.layoutStructure,
+                'ui_components': spec.uiComponents,
+                'color_palette': spec.colorPalette,
+                'typography': spec.typography,
+                'general_design_info': spec.generalDesignInfo,
+                'analysis_timestamp': spec.analysisTimestampIso,
+              },
+      });
+    }
+
+    final payload = <String, Object?>{
+      'export_version': '1.0',
+      'export_timestamp': DateTime.now().toUtc().toIso8601String(),
+      'application_name': 'AI Design Inspiration Hub',
+      'screenshots': out,
+    };
+    await targetFile.writeAsString(const JsonEncoder.withIndent('  ').convert(payload));
+    return targetFile;
+  }
+}

--- a/ai_design_inspiration_hub/lib/features/mcp/mcp_stub.dart
+++ b/ai_design_inspiration_hub/lib/features/mcp/mcp_stub.dart
@@ -1,0 +1,19 @@
+class McpServerStub {
+  bool _running = false;
+  String? _apiKey;
+
+  bool get isRunning => _running;
+  String? get apiKey => _apiKey;
+
+  Future<void> start({required String apiKey}) async {
+    _apiKey = apiKey;
+    _running = true;
+    // In a real implementation, bind to a local port and expose MCP tools.
+  }
+
+  Future<void> stop() async {
+    _running = false;
+  }
+
+  bool validateKey(String? key) => key != null && key.isNotEmpty && key == _apiKey;
+}

--- a/ai_design_inspiration_hub/lib/features/menubar/menubar_stub.dart
+++ b/ai_design_inspiration_hub/lib/features/menubar/menubar_stub.dart
@@ -1,0 +1,5 @@
+class MenubarStub {
+  Future<void> init() async {
+    // Integrate tray_manager when running on macOS with Flutter runtime.
+  }
+}

--- a/ai_design_inspiration_hub/lib/features/upload/upload_stub.dart
+++ b/ai_design_inspiration_hub/lib/features/upload/upload_stub.dart
@@ -1,0 +1,29 @@
+import 'dart:typed_data';
+
+import 'package:uuid/uuid.dart';
+
+import '../../models/screenshot.dart';
+import '../../data/repositories/screenshot_repository.dart';
+import '../../services/storage_service.dart';
+
+class UploadServiceStub {
+  final StorageService _storage = StorageService();
+  final ScreenshotRepository _screensRepo = ScreenshotRepository();
+  final _uuid = const Uuid();
+
+  Future<ScreenshotModel> importImageBytes(Uint8List bytes, {String? originalExtension, String? title}) async {
+    final id = _uuid.v4();
+    final filename = '$id${originalExtension != null ? '.$originalExtension' : '.png'}';
+    await _storage.saveImageBytes(bytes, filename);
+    final nowIso = DateTime.now().toUtc().toIso8601String();
+    final screenshot = ScreenshotModel(
+      id: id,
+      imagePath: filename,
+      uploadTimestampIso: nowIso,
+      title: title,
+      creationDateIso: nowIso,
+    );
+    await _screensRepo.create(screenshot);
+    return screenshot;
+  }
+}

--- a/ai_design_inspiration_hub/lib/main.dart
+++ b/ai_design_inspiration_hub/lib/main.dart
@@ -1,0 +1,7 @@
+import 'package:flutter/widgets.dart';
+import 'app.dart';
+
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  runApp(const InspirationHubApp());
+}

--- a/ai_design_inspiration_hub/lib/models/category.dart
+++ b/ai_design_inspiration_hub/lib/models/category.dart
@@ -1,0 +1,25 @@
+class CategoryModel {
+  final String id;
+  final String name;
+  final String? parentCategoryId;
+
+  const CategoryModel({
+    required this.id,
+    required this.name,
+    this.parentCategoryId,
+  });
+
+  Map<String, Object?> toMap() => {
+        'id': id,
+        'name': name,
+        'parent_category_id': parentCategoryId,
+      };
+
+  static CategoryModel fromMap(Map<String, Object?> map) {
+    return CategoryModel(
+      id: map['id'] as String,
+      name: map['name'] as String,
+      parentCategoryId: map['parent_category_id'] as String?,
+    );
+  }
+}

--- a/ai_design_inspiration_hub/lib/models/design_specification.dart
+++ b/ai_design_inspiration_hub/lib/models/design_specification.dart
@@ -1,0 +1,83 @@
+class DesignSpecificationModel {
+  final String id;
+  final String screenshotId;
+  final Map<String, Object?>? layoutStructure;
+  final List<Map<String, Object?>>? uiComponents;
+  final List<Map<String, Object?>>? colorPalette;
+  final List<Map<String, Object?>>? typography;
+  final Map<String, Object?>? generalDesignInfo;
+  final String? analysisTimestampIso;
+  final String? analysisEngineVersion;
+
+  const DesignSpecificationModel({
+    required this.id,
+    required this.screenshotId,
+    this.layoutStructure,
+    this.uiComponents,
+    this.colorPalette,
+    this.typography,
+    this.generalDesignInfo,
+    this.analysisTimestampIso,
+    this.analysisEngineVersion,
+  });
+
+  Map<String, Object?> toMap() => {
+        'id': id,
+        'screenshot_id': screenshotId,
+        'layout_structure': layoutStructure == null ? null : _encode(layoutStructure!),
+        'ui_components': uiComponents == null ? null : _encode(uiComponents!),
+        'color_palette': colorPalette == null ? null : _encode(colorPalette!),
+        'typography': typography == null ? null : _encode(typography!),
+        'general_design_info': generalDesignInfo == null ? null : _encode(generalDesignInfo!),
+        'analysis_timestamp': analysisTimestampIso,
+        'analysis_engine_version': analysisEngineVersion,
+      };
+
+  static DesignSpecificationModel fromMap(Map<String, Object?> map) {
+    return DesignSpecificationModel(
+      id: map['id'] as String,
+      screenshotId: map['screenshot_id'] as String,
+      layoutStructure: _maybeDecodeMap(map['layout_structure'] as String?),
+      uiComponents: _maybeDecodeList(map['ui_components'] as String?),
+      colorPalette: _maybeDecodeList(map['color_palette'] as String?),
+      typography: _maybeDecodeList(map['typography'] as String?),
+      generalDesignInfo: _maybeDecodeMap(map['general_design_info'] as String?),
+      analysisTimestampIso: map['analysis_timestamp'] as String?,
+      analysisEngineVersion: map['analysis_engine_version'] as String?,
+    );
+  }
+
+  static String _encode(Object value) => _Json.encode(value);
+  static Map<String, Object?>? _maybeDecodeMap(String? json) => json == null ? null : (_Json.decode(json) as Map).cast<String, Object?>();
+  static List<Map<String, Object?>>? _maybeDecodeList(String? json) => json == null ? null : List<Map<String, Object?>>.from((_Json.decode(json) as List).map((e) => (e as Map).cast<String, Object?>()));
+}
+
+// Lightweight JSON helpers to avoid importing dart:convert in many files.
+class _Json {
+  static String encode(Object? value) => _encoder.convert(value);
+  static Object decode(String source) => _decoder.convert(source);
+}
+
+const _encoder = JsonEncoder();
+const _decoder = JsonDecoder();
+
+// Minimal copies to avoid an explicit import at call sites. If desired, replace with dart:convert.
+class JsonEncoder {
+  const JsonEncoder();
+  String convert(Object? value) => _jsonEncode(value);
+}
+
+class JsonDecoder {
+  const JsonDecoder();
+  Object convert(String source) => _jsonDecode(source);
+}
+
+// Implemented via dart:convert but inlined to keep this file standalone.
+// In real app, prefer: import 'dart:convert'; then jsonEncode/jsonDecode.
+Object _jsonDecode(String source) => _realJsonDecode(source);
+String _jsonEncode(Object? value) => _realJsonEncode(value);
+
+// Deferred actual functions from dart:convert to keep file clear; re-export below.
+import 'dart:convert' as _dart_convert show jsonDecode, jsonEncode;
+Object _realJsonDecode(String source) => _dart_convert.jsonDecode(source);
+String _realJsonEncode(Object? value) => _dart_convert.jsonEncode(value);

--- a/ai_design_inspiration_hub/lib/models/screenshot.dart
+++ b/ai_design_inspiration_hub/lib/models/screenshot.dart
@@ -1,0 +1,41 @@
+class ScreenshotModel {
+  final String id;
+  final String? title;
+  final String? description;
+  final String imagePath;
+  final String? creationDateIso;
+  final String? sourceUrl;
+  final String uploadTimestampIso;
+
+  const ScreenshotModel({
+    required this.id,
+    required this.imagePath,
+    required this.uploadTimestampIso,
+    this.title,
+    this.description,
+    this.creationDateIso,
+    this.sourceUrl,
+  });
+
+  Map<String, Object?> toMap() => {
+        'id': id,
+        'title': title,
+        'description': description,
+        'image_path': imagePath,
+        'creation_date': creationDateIso,
+        'source_url': sourceUrl,
+        'upload_timestamp': uploadTimestampIso,
+      };
+
+  static ScreenshotModel fromMap(Map<String, Object?> map) {
+    return ScreenshotModel(
+      id: map['id'] as String,
+      imagePath: map['image_path'] as String,
+      uploadTimestampIso: map['upload_timestamp'] as String,
+      title: map['title'] as String?,
+      description: map['description'] as String?,
+      creationDateIso: map['creation_date'] as String?,
+      sourceUrl: map['source_url'] as String?,
+    );
+  }
+}

--- a/ai_design_inspiration_hub/lib/models/tag.dart
+++ b/ai_design_inspiration_hub/lib/models/tag.dart
@@ -1,0 +1,21 @@
+class TagModel {
+  final String id;
+  final String name;
+
+  const TagModel({
+    required this.id,
+    required this.name,
+  });
+
+  Map<String, Object?> toMap() => {
+        'id': id,
+        'name': name,
+      };
+
+  static TagModel fromMap(Map<String, Object?> map) {
+    return TagModel(
+      id: map['id'] as String,
+      name: map['name'] as String,
+    );
+  }
+}

--- a/ai_design_inspiration_hub/lib/services/database.dart
+++ b/ai_design_inspiration_hub/lib/services/database.dart
@@ -1,0 +1,118 @@
+import 'dart:async';
+
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+import 'package:sqflite/sqflite.dart';
+
+class AppDatabase {
+  static const int _dbVersion = 1;
+  static const String _dbFileName = 'inspiration_hub.db';
+
+  static Database? _database;
+
+  static Future<Database> get database async {
+    if (_database != null) {
+      return _database!;
+    }
+    _database = await _openDatabase();
+    return _database!;
+  }
+
+  static Future<Database> _openDatabase() async {
+    final appSupportDir = await getApplicationSupportDirectory();
+    final dbPath = p.join(appSupportDir.path, _dbFileName);
+    return openDatabase(
+      dbPath,
+      version: _dbVersion,
+      onConfigure: (db) async {
+        await db.execute('PRAGMA foreign_keys = ON');
+      },
+      onCreate: (db, version) async {
+        await _createSchema(db);
+      },
+      onUpgrade: (db, oldVersion, newVersion) async {
+        // Add migration logic when bumping _dbVersion
+      },
+    );
+  }
+
+  static Future<void> _createSchema(Database db) async {
+    // Screenshots table
+    await db.execute('''
+      CREATE TABLE Screenshots (
+        id TEXT PRIMARY KEY,
+        title TEXT,
+        description TEXT,
+        image_path TEXT NOT NULL,
+        creation_date TEXT,
+        source_url TEXT,
+        upload_timestamp TEXT
+      )
+    ''');
+
+    // Tags table
+    await db.execute('''
+      CREATE TABLE Tags (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL UNIQUE
+      )
+    ''');
+
+    // Categories table
+    await db.execute('''
+      CREATE TABLE Categories (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        parent_category_id TEXT,
+        UNIQUE(name, parent_category_id),
+        FOREIGN KEY(parent_category_id) REFERENCES Categories(id) ON DELETE SET NULL
+      )
+    ''');
+
+    // Junction: Screenshot_Tags
+    await db.execute('''
+      CREATE TABLE Screenshot_Tags (
+        screenshot_id TEXT NOT NULL,
+        tag_id TEXT NOT NULL,
+        PRIMARY KEY (screenshot_id, tag_id),
+        FOREIGN KEY(screenshot_id) REFERENCES Screenshots(id) ON DELETE CASCADE,
+        FOREIGN KEY(tag_id) REFERENCES Tags(id) ON DELETE CASCADE
+      )
+    ''');
+
+    // Junction: Screenshot_Categories
+    await db.execute('''
+      CREATE TABLE Screenshot_Categories (
+        screenshot_id TEXT NOT NULL,
+        category_id TEXT NOT NULL,
+        PRIMARY KEY (screenshot_id, category_id),
+        FOREIGN KEY(screenshot_id) REFERENCES Screenshots(id) ON DELETE CASCADE,
+        FOREIGN KEY(category_id) REFERENCES Categories(id) ON DELETE CASCADE
+      )
+    ''');
+
+    // Design_Specifications table
+    await db.execute('''
+      CREATE TABLE Design_Specifications (
+        id TEXT PRIMARY KEY,
+        screenshot_id TEXT NOT NULL UNIQUE,
+        layout_structure TEXT,
+        ui_components TEXT,
+        color_palette TEXT,
+        typography TEXT,
+        general_design_info TEXT,
+        analysis_timestamp TEXT,
+        analysis_engine_version TEXT,
+        FOREIGN KEY(screenshot_id) REFERENCES Screenshots(id) ON DELETE CASCADE
+      )
+    ''');
+
+    // Helpful indexes
+    await db.execute('CREATE INDEX IF NOT EXISTS idx_screenshots_creation_date ON Screenshots(creation_date)');
+    await db.execute('CREATE INDEX IF NOT EXISTS idx_tags_name ON Tags(name)');
+    await db.execute('CREATE INDEX IF NOT EXISTS idx_screenshot_tags_sid ON Screenshot_Tags(screenshot_id)');
+    await db.execute('CREATE INDEX IF NOT EXISTS idx_screenshot_tags_tid ON Screenshot_Tags(tag_id)');
+    await db.execute('CREATE INDEX IF NOT EXISTS idx_screenshot_categories_sid ON Screenshot_Categories(screenshot_id)');
+    await db.execute('CREATE INDEX IF NOT EXISTS idx_screenshot_categories_cid ON Screenshot_Categories(category_id)');
+  }
+}

--- a/ai_design_inspiration_hub/lib/services/storage_service.dart
+++ b/ai_design_inspiration_hub/lib/services/storage_service.dart
@@ -1,0 +1,40 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+class StorageService {
+  static const String _appFolderName = 'AI Design Inspiration Hub';
+  static const String _imagesSubdir = 'Images';
+
+  Future<Directory> ensureAppSupportDir() async {
+    final base = await getApplicationSupportDirectory();
+    final appDir = Directory(p.join(base.path, _appFolderName));
+    if (!await appDir.exists()) {
+      await appDir.create(recursive: true);
+    }
+    return appDir;
+  }
+
+  Future<Directory> ensureImagesDir() async {
+    final appDir = await ensureAppSupportDir();
+    final imagesDir = Directory(p.join(appDir.path, _imagesSubdir));
+    if (!await imagesDir.exists()) {
+      await imagesDir.create(recursive: true);
+    }
+    return imagesDir;
+  }
+
+  Future<File> saveImageBytes(List<int> bytes, String filename) async {
+    final imagesDir = await ensureImagesDir();
+    final file = File(p.join(imagesDir.path, filename));
+    return file.writeAsBytes(bytes, flush: true);
+  }
+
+  Future<File?> getImageFile(String filename) async {
+    final imagesDir = await ensureImagesDir();
+    final file = File(p.join(imagesDir.path, filename));
+    if (await file.exists()) return file;
+    return null;
+  }
+}

--- a/ai_design_inspiration_hub/pubspec.yaml
+++ b/ai_design_inspiration_hub/pubspec.yaml
@@ -1,0 +1,33 @@
+name: ai_design_inspiration_hub
+description: A macOS-focused Flutter app for organizing UI screenshots and serving design specs via MCP.
+publish_to: "none"
+
+version: 0.1.0+1
+
+environment:
+  sdk: ">=3.3.0 <4.0.0"
+  flutter: ">=3.22.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  cupertino_icons: ^1.0.6
+  macos_ui: ^2.0.5
+  sqflite: ^2.3.3
+  path: ^1.9.0
+  path_provider: ^2.1.4
+  uuid: ^4.5.1
+  shared_preferences: ^2.3.2
+  tray_manager: ^0.2.3
+  flutter_riverpod: ^2.5.1
+  image: ^4.2.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^4.0.0
+
+flutter:
+  uses-material-design: false
+  assets:
+    - assets/icons/


### PR DESCRIPTION
Initialize Flutter project scaffold for AI Design Inspiration Hub, including core architecture, data models, SQLite schema, and stubs for key features.

---
<a href="https://cursor.com/background-agent?bcId=bc-4940fee1-54df-4d8a-938f-ec3613dea4d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4940fee1-54df-4d8a-938f-ec3613dea4d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Initial Flutter scaffold for the AI Design Inspiration Hub. Adds a macOS app shell, SQLite data layer, storage, and stubs for upload, analysis, export, MCP, and menubar.

- **New Features**
  - macOS app shell using macos_ui with a simple home screen.
  - SQLite schema and indexes for screenshots, tags, categories, link tables, and design specs.
  - Models, DAOs, and repositories for core entities.
  - Storage service for saving images under Application Support.
  - Stubs: image upload (save bytes, create records), color palette analysis, JSON export, MCP server, menubar.

<!-- End of auto-generated description by cubic. -->

---

🚀 This PR introduces the complete foundational scaffold for the AI Design Inspiration Hub Flutter application, establishing a macOS-native app architecture with SQLite persistence, image storage, and stub implementations for core features like screenshot analysis and MCP server integration. The scaffold provides a solid foundation with proper data models, repository patterns, and service layers ready for feature development.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **App Architecture**: Complete Flutter app scaffold with macOS-native UI using `macos_ui` package, including main app shell and basic home screen
- **Data Layer**: Comprehensive SQLite schema with tables for screenshots, tags, categories, design specifications, and junction tables for many-to-many relationships
- **Models & Persistence**: Full data model classes with serialization/deserialization, DAO pattern implementation, and repository layer for clean architecture
- **Storage Services**: File storage service for managing screenshot images in Application Support directory with proper directory structure
- **Feature Stubs**: Initial implementations for image upload, color palette analysis, JSON export, MCP server, and menubar integration

### Technical Implementation
```mermaid
flowchart TD
    A[Flutter App] --> B[macOS UI Shell]
    A --> C[Services Layer]
    C --> D[Database Service]
    C --> E[Storage Service]
    D --> F[SQLite DB]
    E --> G[File System]
    
    H[Data Layer] --> I[Models]
    H --> J[DAOs]
    H --> K[Repositories]
    
    L[Features] --> M[Upload Stub]
    L --> N[Analysis Stub]
    L --> O[Export Service]
    L --> P[MCP Server Stub]
    L --> Q[Menubar Stub]
    
    J --> F
    K --> J
    M --> K
    N --> K
    O --> K
```

### Impact
- **Development Foundation**: Provides complete architectural foundation with proper separation of concerns, enabling rapid feature development
- **Data Management**: Robust SQLite schema with foreign key constraints, indexes, and proper normalization for scalable data storage
- **macOS Integration**: Native macOS look and feel with proper file system integration and Application Support directory usage
- **Extensibility**: Well-structured stub implementations provide clear extension points for implementing full functionality like MCP server, advanced image analysis, and menubar controls

</details>

_Created with [Palmier](https://www.palmier.io)_